### PR TITLE
Fix interpreter in markdownb

### DIFF
--- a/bin/markdownb
+++ b/bin/markdownb
@@ -1,4 +1,4 @@
-#!node
+#!/usr/bin/env node
 // Converts a markdown file into an HTML file, writing it to a temp file.
 // Then invokes the default browser to open the temp file.
 //


### PR DESCRIPTION
Fixes failures on systems where node isn't in the current dir:

    markdownb npm-in-the-browser.md
    -bash: /usr/local/bin/markdownb: node^M: bad interpreter: No such file or directory