### PR TITLE
Fix Interpreter: execute via shell

### DIFF
--- a/bin/markdown
+++ b/bin/markdown
@@ -1,28 +1,17 @@
-#!node
-// Converts a markdown file into an HTML file, writing it to stdout.
-//
-// Usage:
-//   markdown <filename> [<options>]
-// or
-//   markdown --help
-// to see more detailed usage info.
-//
-var Markdown = require('..').Markdown;
-var opts = require('../lib/getopts')();
-var fileName = opts._[0];
-var verbose = opts.verbose || opts.debug;
-if (verbose) console.error('>>>opts=', opts);
+#!/bin/sh
 
-var md = new Markdown();
-md.debug = opts.debug;
-md.bufmax = 2048;
+if [ "$#" -lt 1 ]; then
+	echo "Usage: markdown myFile.md [<option>]" 
+	exit
+fi
 
-md.render(fileName, opts, function(err) {
-  if (err) {
-    console.error('>>>' + err);
-    process.exit();
-  }
-  if (verbose) console.error('>>>starting to pipe...');
-  md.pipe(process.stdout);
-});
+PWD=$(pwd -P)
+
+nextArg="$0 $PWD/$@"
+
+md_dir="$(dirname $0)"
+
+echo $md_dir
+
+node "$md_dir/markdown_main" $@;
 

--- a/bin/markdown_main
+++ b/bin/markdown_main
@@ -1,0 +1,28 @@
+#!node
+// Converts a markdown file into an HTML file, writing it to stdout.
+//
+// Usage:
+//   markdown <filename> [<options>]
+// or
+//   markdown --help
+// to see more detailed usage info.
+//
+var Markdown = require('..').Markdown;
+var opts = require('../lib/getopts')();
+var fileName = opts._[0];
+var verbose = opts.verbose || opts.debug;
+if (verbose) console.error('>>>opts=', opts);
+
+var md = new Markdown();
+md.debug = opts.debug;
+md.bufmax = 2048;
+
+md.render(fileName, opts, function(err) {
+  if (err) {
+    console.error('>>>' + err);
+    process.exit();
+  }
+  if (verbose) console.error('>>>starting to pipe...');
+  md.pipe(process.stdout);
+});
+

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "markdown.js",
   "bin": {
     "markdown": "./bin/markdown",
+    "markdown_main" : "./markdown_main",
     "markdownb": "./bin/markdownb",
     "github-markdown": "./bin/github-markdown",
     "github-markdownb": "./bin/github-markdownb"


### PR DESCRIPTION
Hi, @cwjohan 
This is fixes #2 
#### why use shell or why not use she-bang solution?
node installed location is differ from others, so sha-bang would also differ from others.

instead of changing
````` sh
#!node
``````
to
````` sh
#!/bin/node 
or
#!/use/local/node 
or
#!/any/possible/location/of/node 
``````

problem still there.

#### safer way to execute command 
````` sh
$ node markdown file.md [<option>]
`````
 So write the command in shell script, let the shell script execute the command

replace markdown with [shell script](https://github.com/chalos/markdown-to-html/blob/facc5d0fb6d041d902bff122f16fab84349214d0/bin/markdown)
rename markdown to [markdown_main](https://github.com/chalos/markdown-to-html/blob/facc5d0fb6d041d902bff122f16fab84349214d0/bin/markdown_main)
