### PR TITLE
Changed to /usr/bin/env node

### DIFF
--- a/bin/github-markdown
+++ b/bin/github-markdown
@@ -1,4 +1,4 @@
-#!node
+#!/usr/bin/env node
 // Converts a markdown file into an HTML file, writing it to stdout.
 // Uses the github API, so it outputs what you will see on github,
 // more or less. Some formatting I would have expected does not happen.

--- a/bin/github-markdownb
+++ b/bin/github-markdownb
@@ -1,4 +1,4 @@
-#!node
+#!/usr/bin/env node
 // Converts a markdown file into an HTML file, writing it to a temp file.
 // Then invokes the default browser to open the temp file.
 //

--- a/bin/markdown
+++ b/bin/markdown
@@ -1,4 +1,4 @@
-#!node
+#!/usr/bin/env node
 // Converts a markdown file into an HTML file, writing it to stdout.
 //
 // Usage:

--- a/bin/markdownb
+++ b/bin/markdownb
@@ -1,4 +1,4 @@
-#!node
+#!/usr/bin/env node
 // Converts a markdown file into an HTML file, writing it to a temp file.
 // Then invokes the default browser to open the temp file.
 //


### PR DESCRIPTION
Changing the interpreter path to /usr/bin/env node from just node will make this work for many more people (at least on Linux and MacOS) out of the box.  I'm not sure if this has any effect on Windows users.