### PR TITLE
Indicating html template

### DIFF
--- a/lib/getopts.js
+++ b/lib/getopts.js
@@ -23,15 +23,17 @@ module.exports = function() {
     .options('t', { alias: 'title'})
     .options('v', { alias: 'verbose', default: false})
     .options('d', { alias: 'debug', default: false})
+    .options('p', { alias: 'template'})
     .boolean(['h', 'v', 'd'])
-    .requiresArg(['f', 's', 'c', 't'])
+    .requiresArg(['f', 's', 'c', 't', 'p'])
     .describe({f: 'Type of file: "gfm" or "markdown"',
                h: 'Highlight any source code in the output',
                s: 'Path to the stylesheet to use',
                c: 'Github user/project to use with #<n> issue number references',
                t: 'Add a page title to the header (e.g., $FILENAME, $DIRNAME, $BASENAME, or $PATHNAME).',
                v: 'Verbose output',
-               d: 'Debug output'})
+               d: 'Debug output',
+               p: 'Optional HTML template file to be used. You can set this template instead of --title and --stylesheet. The only requirement is that the template should contain an outlet named {markdown} to indicate where the markdown code will be placed.'})
     .strict()
     .argv;
 

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -25,12 +25,13 @@ function Markdown() {
 }
 
 Markdown.prototype.render = function(fileName, opts, onDone) {
-  var flavour    = opts.flavor || 'gfm',
-      highlight  = opts.highlight,
-      stylesheet = opts.stylesheet,
-      context    = opts.context,
-      title      = opts.title,
-      titleText  = title;
+  var flavour       = opts.flavor || 'gfm',
+      highlight     = opts.highlight,
+      stylesheet    = opts.stylesheet,
+      context       = opts.context,
+      title         = opts.title,
+      titleText     = title,
+      htmlTemplate  = opts.template;
 
   if (title) {
     var dirName  = path.dirname(fileName),
@@ -111,27 +112,42 @@ Markdown.prototype.render = function(fileName, opts, onDone) {
         else console.error('>>>' + err);
         return;
       }
-      if (stylesheet || title) {
-        if (titleText == null) titleText = fileName;
-        this.cat('<!DOCTYPE html>\n' +
-                 '<html>\n' +
-                 '<head>\n' +
-                 '  <title>' + titleText + '</title>\n');
-        if (stylesheet) {
-          this.cat('  <link rel="stylesheet" href="' + stylesheet + '">\n');
+
+      if (htmlTemplate) {
+        this.cat(fs.readFileSync(htmlTemplate));
+
+        let mdCode = ''
+        if (context) {
+          mdCode = linkify(code, context);
+        } else {
+          mdCode = code;
         }
-        this.cat('</head>\n<body>\n' );
-      }
-
-      if (context) {
-        this.cat( linkify(code, context) );
+        this.replace(mdCode);
       } else {
-        this.cat( code );
-      }
+        if (stylesheet || title) {
+          if (titleText == null) titleText = fileName;
+          this.cat('<!DOCTYPE html>\n' +
+                   '<html>\n' +
+                   '<head>\n' +
+                   '  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>' + 
+                   '  <title>' + titleText + '</title>\n');
+          if (stylesheet) {
+            this.cat('  <link rel="stylesheet" href="' + stylesheet + '">\n');
+          }
+          this.cat('</head>\n<body>\n' );
+        }
 
-      if (stylesheet || title) {
-        this.cat( '</body>\n</html>\n' );
+        if (context) {
+          this.cat( linkify(code, context) );
+        } else {
+          this.cat( code );
+        }
+
+        if (stylesheet || title) {
+          this.cat( '</body>\n</html>\n' );
+        }  
       }
+      
       if (this.debug) console.error('>>>finished getting code');
       this.done = true;
       if (onDone) onDone();
@@ -141,6 +157,10 @@ Markdown.prototype.render = function(fileName, opts, onDone) {
 
 Markdown.prototype.cat = function(data) {
   this.html += data;
+}
+
+Markdown.prototype.replace = function(data) {
+  this.html = this.html.replace('{markdown}', data);
 }
 
 Markdown.prototype._read = function(size) {


### PR DESCRIPTION
Hi and thanks for this converter! Good job!

I've made a small modification because I want to indicate the utf8 charset (because the spanish language) and a custom header an footer.

In order to do this I thought that's a good idea to indicate an html template instead of --title and --stylesheet

You decide if you want to pull my changes.