### PR TITLE
Add support for title substitution with template option enabled.

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -123,6 +123,9 @@ Markdown.prototype.render = function(fileName, opts, onDone) {
           mdCode = code;
         }
         this.replace(mdCode);
+        if(title){
+           this.html=this.html.replace('{title}',titleText);
+        }        
       } else {
         if (stylesheet || title) {
           if (titleText == null) titleText = fileName;
@@ -179,4 +182,3 @@ Markdown.prototype._read = function(size) {
 }
 
 module.exports = Markdown;
-


### PR DESCRIPTION
Add support for title substitution with template option enabled.
Usage: in the template.html header, write "<title>{title}</title>" and pass option -t your_title, and the template title placeholder "{title}" will be replaced by your_title.